### PR TITLE
make script concat language file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint:check": "eslint --print-config src/index.js | eslint-config-prettier-check",
     "i18n:extract": "node scripts/i18n/extractMessages.js",
     "i18n:import": "node scripts/i18n/importFromProperties.js",
+    "i18n:reflect": "node scripts/i18n/concatMessages.js",
     "lerna:publish": "lerna publish --no-git-tag-version --no-push --preid alpha",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",

--- a/scripts/i18n/concatMessages.js
+++ b/scripts/i18n/concatMessages.js
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.cwd();
+const localeConfig = require(`${basePath}/config_frontend/config.json`).locales; // eslint-disable-line
+
+let messages = {};
+const { supported: supportedLocales } = localeConfig;
+const messagesFilePrefix = 'messages_';
+const messagesPath = path.resolve(basePath, 'src/nls/');
+
+function log(...args) {
+  console.log(...args); // eslint-disable-line no-console
+}
+
+supportedLocales.forEach(locale => {
+  log(
+    `load ${path.resolve(messagesPath, `${messagesFilePrefix}${locale}.json`)}`
+  );
+  const message = require(path.resolve(messagesPath,`${messagesFilePrefix}${locale}.json`));  // eslint-disable-line
+  messages = { ...messages, ...message };
+});
+
+log(`make ${path.resolve(messagesPath, 'messages.json')}`);
+
+fs.writeFileSync(
+  path.resolve(messagesPath, 'messages.json'),
+  JSON.stringify(messages, null, 2)
+);
+
+log('\nFinished!\n');

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -81,7 +81,7 @@ import {
   isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
-import messages from '../../nls/messages_en.json';
+import messages from '../../nls/messages.json';
 
 import '../../components/App/App.scss';
 


### PR DESCRIPTION
`$ npm run i18n:reflect`を実行すると、`config_frontend/config.json`内の`locele.supported`に書いてある言語のファイルをくっつけて、`messages.json`を作成するという動作になっています。
読み込みは`messages.json`を読み込むだけです。

問題点
- 言語更新のたびに`$ npm run i18n:reflect`の実行が必要で煩わしい